### PR TITLE
Configure linting on just windows and macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [windows, darwin]
     steps:
       -
         uses: actions/checkout@v4
@@ -31,6 +34,8 @@ jobs:
       -
         name: golangci-lint
         uses: golangci/golangci-lint-action@v4
+        env:
+          GOOS: ${{ matrix.goos }}
         with:
           version: v1.56.2
           working-directory: "./go"

--- a/justfile
+++ b/justfile
@@ -87,7 +87,7 @@ lint:
 
 [macos, linux]
 lint:
-    cd go && golangci-lint run
+    for goos in windows darwin; do (cd go && GOOS=$goos golangci-lint run); done
     golines -w ./go
     find ./go ./{{ PLUGIN }}/icons -type f -name '*.svg' -exec xmllint --pretty 2 --output '{}' '{}' \;
 


### PR DESCRIPTION
There's no support for Stream Deck on Linux, nor for Logitech G Hub on Linux, so there are go files specifically for Windows and for macOS. The Linux runner (and my own WSL environment) won't lint properly, because there are no function definitions available.

So, on the GitHub CI, and in the Linux justfile command, check the linting for both Windows and macOS configurations.